### PR TITLE
feat: allow reactions to also update the rsvp

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -13,9 +13,12 @@ func runBot(token, guildID string) error {
 	if err != nil {
 		return err
 	}
+	dg.Identify.Intents = discordgo.IntentGuildMessages | discordgo.IntentGuildMessageReactions
 
 	dg.AddHandler(onReady)
 	dg.AddHandler(onMessageCreate)
+	dg.AddHandler(onReactionAdd)
+	dg.AddHandler(onReactionRemove)
 	dg.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		// Log commands and modal submits for auditing
 		switch i.Type {

--- a/db.go
+++ b/db.go
@@ -184,6 +184,28 @@ func UpsertResponse(eventID int64, userID, responseType string) error {
 	return err
 }
 
+// GetUserResponse returns a user's RSVP for an event, or "" if none.
+func GetUserResponse(eventID int64, userID string) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("db not initialized")
+	}
+	var resp string
+	err := db.QueryRow(`SELECT response_type FROM event_responses WHERE event_id = $1 AND user_id = $2`, eventID, userID).Scan(&resp)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return resp, err
+}
+
+// DeleteResponse removes a user's RSVP for an event.
+func DeleteResponse(eventID int64, userID string) error {
+	if db == nil {
+		return fmt.Errorf("db not initialized")
+	}
+	_, err := db.Exec(`DELETE FROM event_responses WHERE event_id = $1 AND user_id = $2`, eventID, userID)
+	return err
+}
+
 // GetResponsesForEvent returns lists of user IDs for each response type.
 func GetResponsesForEvent(eventID int64) (going, maybe, cant []string, err error) {
 	if db == nil {

--- a/event_creation.go
+++ b/event_creation.go
@@ -162,6 +162,8 @@ func handleEventCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		}
 		if _, err := CreateEvent(ch.ID, sent.ID, emoji, eventName, location, price, i.Member.User.ID, when); err != nil {
 			log.Printf("Failed to persist event to DB: %v", err)
+		} else {
+			addRSVPReactions(s, ch.ID, sent.ID)
 		}
 		if err := InsertMessage(sent.ID, ch.ID, channelName, s.State.User.ID, s.State.User.Username, sent.Content); err != nil {
 			log.Printf("Failed to insert bot message into DB: %v", err)

--- a/help.go
+++ b/help.go
@@ -27,7 +27,7 @@ func handleHelpCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	helpMessage := "**Available Commands:**\n" +
 		"1. `/help` - Get a list of available commands.\n" +
 		"2. `/event [name] [time] [location] [emoji] [price]` - Announce an event in the current channel.\n" +
-		"3. `/rsvp [yes/no/maybe] (@user optional) - RSVP to an event; you can RSVP for others by mentioning them (e.g. <@123...>).\n" +
+		"3. `/rsvp [yes/no/maybe] (@user optional) - RSVP to an event; you can also react with ✅ / ❓ / ❌ on the event post.\n" +
 		"4. `/change_name [name]` - Change the name of the event.\n" +
 		"5. `/change_date [new_date]` - Change the event's date/time in the current channel.\n" +
 		"6. `/change_location [new_location]` - Change the event location.\n" +

--- a/reactions.go
+++ b/reactions.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"log"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var rsvpReactionEmojis = []struct {
+	emoji    string
+	response string
+}{
+	{"✅", "yes"},
+	{"❓", "maybe"},
+	{"❌", "no"},
+}
+
+func addRSVPReactions(s *discordgo.Session, channelID, messageID string) {
+	for _, r := range rsvpReactionEmojis {
+		if err := s.MessageReactionAdd(channelID, messageID, r.emoji); err != nil {
+			log.Printf("Failed to add RSVP reaction %s: %v", r.emoji, err)
+		}
+	}
+}
+
+func responseFromReactionEmoji(emoji discordgo.Emoji) string {
+	if emoji.ID != "" {
+		return ""
+	}
+	switch emoji.Name {
+	case "✅", "white_check_mark", "☑️", "✔️":
+		return "yes"
+	case "❓", "question", "?":
+		return "maybe"
+	case "❌", "x", "❎", "negative_squared_cross_mark":
+		return "no"
+	default:
+		return ""
+	}
+}
+
+func reactionUserID(r *discordgo.MessageReaction) string {
+	if r == nil {
+		return ""
+	}
+	if r.UserID != "" {
+		return r.UserID
+	}
+	return ""
+}
+
+func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
+	if r == nil || r.MessageReaction == nil {
+		return
+	}
+	userID := reactionUserID(r.MessageReaction)
+	if userID == "" && r.Member != nil && r.Member.User != nil {
+		userID = r.Member.User.ID
+	}
+	if userID == "" || userID == s.State.User.ID {
+		return
+	}
+
+	response := responseFromReactionEmoji(r.Emoji)
+	if response == "" {
+		return
+	}
+
+	ev, err := GetEventByChannel(r.ChannelID)
+	if err != nil || ev.MessageID == "" || ev.MessageID != r.MessageID {
+		return
+	}
+
+	if err := UpsertResponse(ev.ID, userID, response); err != nil {
+		log.Printf("Failed to persist RSVP from reaction: %v", err)
+		return
+	}
+
+	clearOtherRSVPReactions(s, r.ChannelID, r.MessageID, userID, r.Emoji)
+	refreshEventMessage(s, r.ChannelID)
+}
+
+func onReactionRemove(s *discordgo.Session, r *discordgo.MessageReactionRemove) {
+	if r == nil || r.MessageReaction == nil {
+		return
+	}
+	userID := reactionUserID(r.MessageReaction)
+	if userID == "" || userID == s.State.User.ID {
+		return
+	}
+
+	response := responseFromReactionEmoji(r.Emoji)
+	if response == "" {
+		return
+	}
+
+	ev, err := GetEventByChannel(r.ChannelID)
+	if err != nil || ev.MessageID == "" || ev.MessageID != r.MessageID {
+		return
+	}
+
+	current, err := GetUserResponse(ev.ID, userID)
+	if err != nil {
+		log.Printf("Failed to load RSVP for reaction remove: %v", err)
+		return
+	}
+	if current != response {
+		return
+	}
+
+	if err := DeleteResponse(ev.ID, userID); err != nil {
+		log.Printf("Failed to remove RSVP from reaction: %v", err)
+		return
+	}
+	refreshEventMessage(s, r.ChannelID)
+}
+
+func clearOtherRSVPReactions(s *discordgo.Session, channelID, messageID, userID string, added discordgo.Emoji) {
+	addedResponse := responseFromReactionEmoji(added)
+	if addedResponse == "" {
+		return
+	}
+	for _, r := range rsvpReactionEmojis {
+		if r.response == addedResponse {
+			continue
+		}
+		if err := s.MessageReactionRemove(channelID, messageID, r.emoji, userID); err != nil {
+			log.Printf("Failed to clear RSVP reaction %s for user %s: %v", r.emoji, userID, err)
+		}
+	}
+}

--- a/render.go
+++ b/render.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"log"
 	"text/template"
 	"time"
+
+	"github.com/bwmarrin/discordgo"
 )
 
 //go:embed event.tmpl
@@ -73,4 +76,19 @@ func RenderEventMessage(channelID string) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func refreshEventMessage(s *discordgo.Session, channelID string) {
+	ev, err := GetEventByChannel(channelID)
+	if err != nil || ev.MessageID == "" {
+		return
+	}
+	rendered, err := RenderEventMessage(channelID)
+	if err != nil {
+		log.Printf("Failed to render event message: %v", err)
+		return
+	}
+	if _, err := s.ChannelMessageEdit(channelID, ev.MessageID, rendered); err != nil {
+		log.Printf("Failed to update event message: %v", err)
+	}
 }

--- a/rsvp.go
+++ b/rsvp.go
@@ -83,14 +83,7 @@ func handleRSVPCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	// Re-render message and edit
-	if ev.MessageID != "" {
-		if rendered, rerr := RenderEventMessage(i.ChannelID); rerr == nil {
-			if _, err := s.ChannelMessageEdit(i.ChannelID, ev.MessageID, rendered); err != nil {
-				log.Printf("Failed to update RSVP message: %v", err)
-			}
-		}
-	}
+	refreshEventMessage(s, i.ChannelID)
 
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -150,14 +143,7 @@ func handleRSVPMessage(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
-	// Re-render and edit the event message if present
-	if ev.MessageID != "" {
-		if rendered, rerr := RenderEventMessage(m.ChannelID); rerr == nil {
-			if _, err := s.ChannelMessageEdit(m.ChannelID, ev.MessageID, rendered); err != nil {
-				log.Printf("Failed to update RSVP message (message): %v", err)
-			}
-		}
-	}
+	refreshEventMessage(s, m.ChannelID)
 
 	_, _ = s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("RSVP updated for %s: %s", userMention, response))
 }


### PR DESCRIPTION
Users can RSVP by reacting on the event announcement post, in addition to /rsvp.
- New events get ✅ / ❓ / ❌ reactions on the announcement (Going / Maybe / Can't make it).
- MessageReactionAdd / MessageReactionRemove handlers map those reactions to yes / maybe / no, persist via existing UpsertResponse / DeleteResponse, and refresh the event post.
- Switching reactions keeps one RSVP per user (other RSVP reactions are cleared on the message).
- /rsvp still works; both paths share a new refreshEventMessage helper.


I did not test this :^)